### PR TITLE
sendTransactionAsync should return txHash string

### DIFF
--- a/packages/subproviders/src/subproviders/ledger.ts
+++ b/packages/subproviders/src/subproviders/ledger.ts
@@ -233,7 +233,7 @@ export class LedgerSubprovider extends Subprovider {
         this._ledgerClientIfExists = undefined;
         this._connectionLock.signal();
     }
-    private async _sendTransactionAsync(txParams: PartialTxParams): Promise<Web3.JSONRPCResponsePayload> {
+    private async _sendTransactionAsync(txParams: PartialTxParams): Promise<string> {
         await this._nonceLock.wait();
         try {
             // fill in the extras
@@ -247,7 +247,7 @@ export class LedgerSubprovider extends Subprovider {
             };
             const result = await this.emitPayloadAsync(payload);
             this._nonceLock.signal();
-            return result;
+            return result.result;
         } catch (err) {
             this._nonceLock.signal();
             throw err;


### PR DESCRIPTION
This PR:
* _sendTransactionAsync is currently returning an object containing json rpc version, id, and result, where result is the txHash. The rest of the 0x/web3 machinery expects a string representing txHash to come back here.
